### PR TITLE
Update Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,6 +93,7 @@ pipeline{
 		            def downloadPath = "${env.ABS_DOWNLOAD_PATH}/${releaseVersion}"
 		            sh "cp diagram_converter_graph_database.dump*tgz ${finalGraphDbArchive}"
 		            sh "cp ${finalGraphDbArchive} ${downloadPath}/"
+			    sh "if [ -d ${downloadPath}/diagram/ ]; then rm ${downloadPath}/diagram/*; fi"
 		            sh "mv ${env.OUTPUT_FOLDER} ${downloadPath}/ "
 		        }
 		    }


### PR DESCRIPTION
The diagrams folder is populated when creating the test slices. With this change, we are making sure to delete the test slice diagram before we populate the diagram folder.