### PR TITLE
Update Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,23 @@ pipeline{
 				}
 			}
 		}
+		stage('Confirm Converter Output Error Free'){
+			steps{
+				// This is because the output can have silent errors from the Diagram Converter.
+				script{
+					def userInput = input(
+					id: 'userInput', message: "Can comfirm ther are no errors in the output from running the converter",
+					parameters: [
+						[$class: 'BooleanParameterDefinition', defaultValue: true, name: 'response']
+					])
+
+					if (!userInput){
+						error("Please re-run the Converter step")
+					}
+				}
+			}
+		}
+		
 		// There are generally over 30k JSON diagram files produced in a typical release.
 		// This stage gets the file counts between the current and previous release, which allows for quick review.
 		stage('Post: Compare previous release file number') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,7 +110,7 @@ pipeline{
 		            def downloadPath = "${env.ABS_DOWNLOAD_PATH}/${releaseVersion}"
 		            sh "cp diagram_converter_graph_database.dump*tgz ${finalGraphDbArchive}"
 		            sh "cp ${finalGraphDbArchive} ${downloadPath}/"
-			    sh "if [ -d ${downloadPath}/diagram/ ]; then rm ${downloadPath}/diagram/*; fi"
+			    sh "rm -rf ${downloadPath}/diagram/"
 		            sh "mv ${env.OUTPUT_FOLDER} ${downloadPath}/ "
 		        }
 		    }


### PR DESCRIPTION
This is because the output can have silent errors from the Diagram Converter.