### PR TITLE
No longer required now that bug has been fixed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,23 +52,6 @@ pipeline{
 				}
 			}
 		}
-		stage('Confirm Converter Output Error Free'){
-			steps{
-				// This asks for confirmation the configuration file has been updated for this release.
-				// This is a locally-scoped secret file accessed at Jenkins -> Releases -> ## (release number) -> Credentials -> Config
-				script{
-					def userInput = input(
-					id: 'userInput', message: "Can comfirm ther are no errors in the output from running the converter",
-					parameters: [
-						[$class: 'BooleanParameterDefinition', defaultValue: true, name: 'response']
-					])
-
-					if (!userInput){
-						error("Please re-run the Converter step")
-					}
-				}
-			}
-		}
 		
 		// There are generally over 30k JSON diagram files produced in a typical release.
 		// This stage gets the file counts between the current and previous release, which allows for quick review.


### PR DESCRIPTION
This was required when I have to look at the output for errors. Everything seams to be working without error now. Step no longer needed