### PR TITLE
changing version of reactome-base

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <dependency>
             <groupId>org.reactome.base</groupId>
             <artifactId>reactome-base</artifactId>
+            <version>2.2.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-httpclient</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.reactome.base</groupId>
             <artifactId>reactome-base</artifactId>
-            <version>2.2.1-SNAPSHOT</version>
+            <version>2.2.2-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-httpclient</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+             
         <!--JSAP console reader-->
         <dependency>
             <groupId>com.martiansoftware</groupId>


### PR DESCRIPTION
This change is made to be able to handle the Cytomics fields that are present in the latest slice database. The jackson-databind dependency is not needed inside the reactome-base itself so it has been removed. We can discuss this decision in between releases and come up with a plan across all the repos that depend on reactome-base. 